### PR TITLE
submenu 에서 url prefix 가 겹칠 경우 두 개이상이 표시되는 오류 수정

### DIFF
--- a/pyconkr/context_processors.py
+++ b/pyconkr/context_processors.py
@@ -88,7 +88,7 @@ def default(request):
 
                 for sk, sv in v['submenu'].items():
                     sv['path'] = '{}{}/'.format(path, sk)
-                    subpath = sv['path'][:-2]
+                    subpath = sv['path'][:-1]
 
                     if rp.startswith(subpath):
                         sv['active'] = True


### PR DESCRIPTION
/pyconkr/contact 를 들어가면 /pyconkr/coc 와 /co가 서로 동일하게 되어 둘 다 하이라이팅 되는 버그를 수정