### PR TITLE
헤더 색상 수정 

### DIFF
--- a/pyconkr/static/css/pyconkr.css
+++ b/pyconkr/static/css/pyconkr.css
@@ -59,9 +59,13 @@ input[type=file] {
 .navbar {
     padding: 10px 0;
     margin-bottom: 0px !important;
-    background: rgba(0, 40, 122, 0.85);
+    background-color: #002E7A;
     border: 0;
     border-radius: 0;
+}
+
+.onsky > .navbar {
+    background: none;
 }
 
 .navbar .navbar-nav>li>a {

--- a/pyconkr/static/css/pyconkr.css
+++ b/pyconkr/static/css/pyconkr.css
@@ -59,7 +59,7 @@ input[type=file] {
 .navbar {
     padding: 10px 0;
     margin-bottom: 0px !important;
-    background: none;
+    background: rgba(0, 40, 122, 0.85);
     border: 0;
     border-radius: 0;
 }


### PR DESCRIPTION
#42 헤더 배경 색상이 적용되지 않은 것 같아보여 메인의 색과 동일한 색으로 배경 색으로 통일했습니다.
rgba(0, 40, 122, 0.85)가 좀 더 잘어울리는 것 같은데 rgba 스펙의 브라우저 호환정보를 잘 모르겠어서 그냥 일반 hex 값으로 넣었어요.