### PR TITLE
Bracket에 의해 메뉴에 포인터가 가려지는 현상 수정

### DIFF
--- a/pyconkr/static/css/pyconkr.css
+++ b/pyconkr/static/css/pyconkr.css
@@ -695,6 +695,7 @@ input[type=file] {
 .bracket_fill, .bracket_line {
     position: absolute;
     z-index: 2;
+    pointer-events: none;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Bracket에 의해 메뉴에 포인터가 가려지는 현상 수정
https://github.com/pythonkr/pyconkr-2017/issues/44
