### PR TITLE
disqus 이름 PyCon APAC 2016에서 PyCon KR 2017로 변경

### DIFF
--- a/pyconkr/templates/disqus.html
+++ b/pyconkr/templates/disqus.html
@@ -2,7 +2,7 @@
 <h3>{% trans "Comments" %}</h3>
 <div id="disqus_thread"></div>
 <script type="text/javascript">
-    var disqus_shortname = 'pyconapac2016';
+    var disqus_shortname = 'pycon-korea-2017';
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
Issue by https://github.com/pythonkr/pyconkr-2017/issues/63

Before
<img width="1401" alt="screen shot 2017-07-01 at 6 00 45 pm" src="https://user-images.githubusercontent.com/1144643/27760632-39273f5a-5e87-11e7-81af-91d3a23545a6.png">

---

After
<img width="1294" alt="screen shot 2017-07-01 at 5 59 31 pm" src="https://user-images.githubusercontent.com/1144643/27760622-179809aa-5e87-11e7-8563-38d910efb236.png">
