### PR TITLE
Get manual payment objects with request.user and set raw_id_fields(user)

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -125,6 +125,7 @@ class ManualPaymentAdmin(admin.ModelAdmin):
     list_display = ('title', 'payment_status', 'user', )
     list_filter = ('payment_status', )
     search_fields = ('user__email', 'description', )
+    raw_id_fields = ('user', )
 
     class Meta:
         model = ManualPayment

--- a/registration/views.py
+++ b/registration/views.py
@@ -233,7 +233,7 @@ def payment_callback(request):
 
 @login_required
 def manual_registration(request, manual_payment_id):
-    mp = get_object_or_404(ManualPayment, pk=manual_payment_id)
+    mp = get_object_or_404(ManualPayment, pk=manual_payment_id, user=request.user)
     uid = str(uuid4()).replace('-', '')
     form = ManualPaymentForm(initial={
         'title': mp.title,


### PR DESCRIPTION
수동결제 패이지 처음 진입 시 로그인 여부 확인 이후 ManualPayment object 를 가져올 때 user 조건도 추가합니다.
또한 admin 에서 user 를 선택할 때 raw_id_fields 로 지정하여 검색해서 찾을 수 있게 볕경했습니다.