### PR TITLE
SprintProposalDetail 페이지에 HTML/오픈그래프 제목 및 설명 추가

### DIFF
--- a/pyconkr/templates/pyconkr/sprintproposal_detail.html
+++ b/pyconkr/templates/pyconkr/sprintproposal_detail.html
@@ -3,6 +3,10 @@
 {% load thumbnail %}
 {% load crispy_forms_tags %}
 
+{% block head-title %}{{ sprint.title }} &mdash; {{ block.super }}{% endblock %}
+{% block og-title %}{{ sprint.title }}{% endblock %}
+{% block og-desc %}{{ sprint.project_brief }}{% endblock %}
+
 {% block title %}
 <h1>
     {{ sprint.title }}

--- a/pyconkr/templates/pyconkr/tutorialproposal_detail.html
+++ b/pyconkr/templates/pyconkr/tutorialproposal_detail.html
@@ -3,6 +3,10 @@
 {% load thumbnail %}
 {% load crispy_forms_tags %}
 
+{% block head-title %}{{ tutorial.title }} &mdash; {{ block.super }}{% endblock %}
+{% block og-title %}{{ tutorial.title }}{% endblock %}
+{% block og-desc %}{{ tutorial.brief }}{% endblock %}
+
 {% block title %}
 <h1>
     {{ tutorial.title }}


### PR DESCRIPTION
소셜 미디어로 홍보할 때 필요할 것 같아서 추가했습니다.