### PR TITLE
Profile 페이지 organization, phone없을 시 none대신 empry string 출력

### DIFF
--- a/pyconkr/templates/pyconkr/profile_detail.html
+++ b/pyconkr/templates/pyconkr/profile_detail.html
@@ -21,8 +21,8 @@
                     <a href="{% url 'profile_edit' %}"><i class="fa fa-pencil-square-o"></i></a>
                 </h3>
 
-                <h4>{{ profile.organization }}</h4>
-                <p>{{ profile.phone }}</p>
+                <h4>{{ profile.organization|default_if_none:'' }}</h4>
+                <p>{{ profile.phone|default_if_none:'' }}</p>
                 <div>{{ profile.bio|safe }}</div>
             </div>
         </div>

--- a/pyconkr/templates/pyconkr/profile_detail.html
+++ b/pyconkr/templates/pyconkr/profile_detail.html
@@ -21,8 +21,12 @@
                     <a href="{% url 'profile_edit' %}"><i class="fa fa-pencil-square-o"></i></a>
                 </h3>
 
-                <h4>{{ profile.organization|default_if_none:'' }}</h4>
-                <p>{{ profile.phone|default_if_none:'' }}</p>
+                {% if profile.organization %}
+                  <h4>{{ profile.organization }}</h4>
+                {% endif %}
+                {% if profile.phone %}
+                  <p>{{ profile.phone }}</p>
+                {% endif %}
                 <div>{{ profile.bio|safe }}</div>
             </div>
         </div>


### PR DESCRIPTION
유저 프로필에서 소속과 전화번호를 입력하지 않았을 때 나오는 None을 없앴습니다.

![wtih_none](https://user-images.githubusercontent.com/3931792/29158159-ed5695da-7de4-11e7-8e76-3fed67fdc36b.png)
